### PR TITLE
Added support for dynamic store retrievers to storeMixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,34 @@ React.render(<Counter/>, document.body);
 
 A working demo is available in the `demo/` directory in this repository and [on JSBin](http://jsbin.com/meholi/2/edit).
 
+Dynamic store retriever
+-----------------------
+
+When applying the `storeMixin` at react class declaration time, it might happen that your store instance isn't created just yet; in that case you can pass a function to the `storeMixin` function instead of a store object:
+
+```js
+// registry module
+module.exports = {};
+
+// app module
+var registry = require("registry")
+// …
+registry.timeStore = new TimeStore();
+// …
+
+// view module
+var registry = require("registry");
+var Counter = React.createClass({
+  mixins: [DocBrown.storeMixin(function() {
+    return registry.timeStore;
+  })],
+  actions: [Actions],
+  // …
+});
+```
+
+That way, the mixin will only try to retrieve the store instance at component mount time.
+
 Install
 =======
 

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@
       (this.actionHandlers[action] || []).forEach(function(store) {
         if (typeof store[action] === "function") {
           store[action].apply(store, actionArgs);
-        } else {}
+        }
       });
     },
     registeredFor: function(action) {
@@ -138,11 +138,21 @@
   };
 
   DocBrown.storeMixin = function(store) {
-    if (!store) {
-      throw new Error("Missing store");
+    var _getStore;
+    if (typeof store === "function") {
+      _getStore = store;
+    } else if (typeof store === "object") {
+      _getStore = function() {
+        return store;
+      };
+    } else {
+      throw new Error("Unsupported store retriever.");
     }
     return {
       getStore: function() {
+        var store = _getStore();
+        if (!store)
+          throw new Error("Missing store");
         return store;
       },
       getInitialState: function() {
@@ -150,13 +160,13 @@
         this.__changeListener = function(state) {
           this.setState(state);
         }.bind(this);
-        return store.getState();
+        return this.getStore().getState();
       },
       componentDidMount: function() {
-        store.subscribe(this.__changeListener);
+        this.getStore().subscribe(this.__changeListener);
       },
       componentWillUnmount: function() {
-        store.unsubscribe(this.__changeListener);
+        this.getStore().unsubscribe(this.__changeListener);
         delete this.__changeListener;
       }
     };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Flux experiment.",
   "main": "index.js",
   "scripts": {
-    "test": "istanbul cover node_modules/.bin/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage"
+    "test": "istanbul cover node_modules/.bin/_mocha --report html --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage"
   },
   "devDependencies": {
     "chai": "^1.10.0",

--- a/test.js
+++ b/test.js
@@ -404,10 +404,28 @@ describe("DocBrown.createStore()", function() {
 });
 
 describe("DocBrown.storeMixin()", function() {
-  it("should require a store", function() {
+  it("should require a store retriever", function() {
     expect(function() {
       DocBrown.storeMixin();
-    }).to.Throw("Missing store");
+    }).to.Throw("Unsupported store retriever.");
+  });
+
+  it("should accept a store instance as a retriever", function() {
+    var fakeStore = {fakeStore: true};
+
+    var mixin = DocBrown.storeMixin(fakeStore);
+
+    expect(mixin.getStore()).eql(fakeStore);
+  });
+
+  it("should accept a function as a retriever", function() {
+    var fakeStore = {fakeStore: true};
+
+    var mixin = DocBrown.storeMixin(function() {
+      return fakeStore;
+    });
+
+    expect(mixin.getStore()).eql(fakeStore);
   });
 
   describe("constructed", function() {
@@ -418,7 +436,9 @@ describe("DocBrown.storeMixin()", function() {
       Actions = DocBrown.createActions(dispatcher, ["foo"]);
       var Store = DocBrown.createStore({actions: [Actions]});
       store = new Store();
-      mixin = DocBrown.storeMixin(store);
+      mixin = DocBrown.storeMixin(function() {
+        return store;
+      });
     });
 
     it("should create an object", function() {


### PR DESCRIPTION
Excerpt from docs update:

Dynamic store retriever
-----------------------

When applying the `storeMixin` at react class declaration time, it might happen that your store instance isn't created just yet; in that case you can pass a function to the `storeMixin` function instead of a store object:

```js
// registry module
module.exports = {};

// app module
var registry = require("registry")
// …
registry["timeStore"] = new TimeStore();
// …

// view module
var registry = require("registry");
var Counter = React.createClass({
  mixins: [DocBrown.storeMixin(function() {
    return registry["timeStore"];
  })],
  actions: [Actions],
  // …
});
```

That way, the mixin will only try to retrieve the store instance at component mount time.